### PR TITLE
Add support for in-memory encoding

### DIFF
--- a/3rd_party/stb/stb_image_write.h
+++ b/3rd_party/stb/stb_image_write.h
@@ -1,18 +1,27 @@
 /* stb_image_write - v1.16 - public domain - http://nothings.org/stb
    writes out PNG/BMP/TGA/JPEG/HDR images to C stdio - Sean Barrett 2010-2015
                                      no warranty implied; use at your own risk
+
    Before #including,
+
        #define STB_IMAGE_WRITE_IMPLEMENTATION
+
    in the file that you want to have the implementation.
+
    Will probably not work correctly with strict-aliasing optimizations.
+
 ABOUT:
+
    This header file is a library for writing images to C stdio or a callback.
+
    The PNG output is not optimal; it is 20-50% larger than the file
    written by a decent optimizing implementation; though providing a custom
    zlib compress function (see STBIW_ZLIB_COMPRESS) can mitigate that.
    This library is designed for source code compactness and simplicity,
    not optimal image file size or run-time performance.
+
 BUILDING:
+
    You can #define STBIW_ASSERT(x) before the #include to avoid using assert.h.
    You can #define STBIW_MALLOC(), STBIW_REALLOC(), and STBIW_FREE() to replace
    malloc,realloc,free.
@@ -22,37 +31,51 @@ BUILDING:
    unsigned char * my_compress(unsigned char *data, int data_len, int *out_len, int quality);
    The returned data will be freed with STBIW_FREE() (free() by default),
    so it must be heap allocated with STBIW_MALLOC() (malloc() by default),
+
 UNICODE:
+
    If compiling for Windows and you wish to use Unicode filenames, compile
    with
        #define STBIW_WINDOWS_UTF8
    and pass utf8-encoded filenames. Call stbiw_convert_wchar_to_utf8 to convert
    Windows wchar_t filenames to utf8.
+
 USAGE:
+
    There are five functions, one for each image file format:
+
      int stbi_write_png(char const *filename, int w, int h, int comp, const void *data, int stride_in_bytes);
      int stbi_write_bmp(char const *filename, int w, int h, int comp, const void *data);
      int stbi_write_tga(char const *filename, int w, int h, int comp, const void *data);
      int stbi_write_jpg(char const *filename, int w, int h, int comp, const void *data, int quality);
      int stbi_write_hdr(char const *filename, int w, int h, int comp, const float *data);
+
      void stbi_flip_vertically_on_write(int flag); // flag is non-zero to flip data vertically
+
    There are also five equivalent functions that use an arbitrary write function. You are
    expected to open/close your file-equivalent before and after calling these:
+
      int stbi_write_png_to_func(stbi_write_func *func, void *context, int w, int h, int comp, const void  *data, int stride_in_bytes);
      int stbi_write_bmp_to_func(stbi_write_func *func, void *context, int w, int h, int comp, const void  *data);
      int stbi_write_tga_to_func(stbi_write_func *func, void *context, int w, int h, int comp, const void  *data);
      int stbi_write_hdr_to_func(stbi_write_func *func, void *context, int w, int h, int comp, const float *data);
      int stbi_write_jpg_to_func(stbi_write_func *func, void *context, int x, int y, int comp, const void *data, int quality);
+
    where the callback is:
       void stbi_write_func(void *context, void *data, int size);
+
    You can configure it with these global variables:
       int stbi_write_tga_with_rle;             // defaults to true; set to 0 to disable RLE
       int stbi_write_png_compression_level;    // defaults to 8; set to higher for more compression
       int stbi_write_force_png_filter;         // defaults to -1; set to 0..5 to force a filter mode
+
+
    You can define STBI_WRITE_NO_STDIO to disable the file variant of these
    functions, so the library will not use stdio.h at all. However, this will
    also disable HDR writing, because it requires stdio for formatted output.
+
    Each function returns 0 on failure and non-0 on success.
+
    The functions create an image file defined by the parameters. The image
    is a rectangle of pixels stored from left-to-right, top-to-bottom.
    Each pixel contains 'comp' channels of data stored interleaved with 8-bits
@@ -61,26 +84,35 @@ USAGE:
    The *data pointer points to the first byte of the top-left-most pixel.
    For PNG, "stride_in_bytes" is the distance in bytes from the first byte of
    a row of pixels to the first byte of the next row of pixels.
+
    PNG creates output files with the same number of components as the input.
    The BMP format expands Y to RGB in the file format and does not
    output alpha.
+
    PNG supports writing rectangles of data even when the bytes storing rows of
    data are not consecutive in memory (e.g. sub-rectangles of a larger image),
    by supplying the stride between the beginning of adjacent rows. The other
    formats do not. (Thus you cannot write a native-format BMP through the BMP
    writer, both because it is in BGR order and because it may have padding
    at the end of the line.)
+
    PNG allows you to set the deflate compression level by setting the global
    variable 'stbi_write_png_compression_level' (it defaults to 8).
+
    HDR expects linear float data. Since the format is always 32-bit rgb(e)
    data, alpha (if provided) is discarded, and for monochrome data it is
    replicated across all three channels.
+
    TGA supports RLE or non-RLE compressed data. To use non-RLE-compressed
    data, set the global variable 'stbi_write_tga_with_rle' to 0.
+
    JPEG does ignore alpha channels in input data; quality is between 1 and 100.
    Higher quality looks better but results in a bigger image.
    JPEG baseline (no JPEG progressive).
+
 CREDITS:
+
+
    Sean Barrett           -    PNG/BMP/TGA
    Baldur Karlsson        -    HDR
    Jean-Sebastien Guay    -    TGA monochrome
@@ -90,6 +122,7 @@ CREDITS:
    Jon Olick              -    original jo_jpeg.cpp code
    Daniel Gibson          -    integrate JPEG, allow external zlib
    Aarni Koskela          -    allow choosing PNG filter
+
    bugfixes:
       github:Chribba
       Guillaume Chereau
@@ -108,8 +141,11 @@ CREDITS:
       github:ignotion
       Adam Schackart
       Andrew Kensler
+
 LICENSE
+
   See end of file for license information.
+
 */
 
 #ifndef INCLUDE_STB_IMAGE_WRITE_H
@@ -1600,6 +1636,7 @@ STBIWDEF int stbi_write_jpg(char const *filename, int x, int y, int comp, const 
       1.13
       1.12
       1.11  (2019-08-11)
+
       1.10  (2019-02-07)
              support utf8 filenames in Windows; fix warnings and platform ifdefs
       1.09  (2018-02-11)

--- a/c_src/stb_image_nif.c
+++ b/c_src/stb_image_nif.c
@@ -204,18 +204,18 @@ static ERL_NIF_TERM gif_from_binary(ErlNifEnv *env, int argc, const ERL_NIF_TERM
 
 static ERL_NIF_TERM to_file(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     if (argc != 6) {
-        return error(env, "expecting 6 arguments: path, extension, data, height, width, and number of channels");
+        return error(env, "expecting 6 arguments: path, format, data, height, width, and number of channels");
     }
 
-    char path[MAX_NAME_LENGTH], extension[MAX_EXTNAME_LENGTH];
+    char path[MAX_NAME_LENGTH], format[MAX_EXTNAME_LENGTH];
     ErlNifBinary result;
     int w, h, comp;
 
     if (!enif_get_string(env, argv[0], path, sizeof(path), ERL_NIF_LATIN1)) {
         return error(env, "invalid path");
     }
-    if (!enif_get_atom(env, argv[1], extension, sizeof(extension), ERL_NIF_LATIN1)) {
-        return error(env, "invalid extension");
+    if (!enif_get_atom(env, argv[1], format, sizeof(format), ERL_NIF_LATIN1)) {
+        return error(env, "invalid format");
     }
     if (!enif_inspect_binary(env, argv[2], &result)) {
         return error(env, "invalid binary data");
@@ -230,30 +230,30 @@ static ERL_NIF_TERM to_file(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
         return error(env, "invalid number of channels");
     }
 
-    if (strcmp(extension, "png") == 0) {
+    if (strcmp(format, "png") == 0) {
         int stride_in_bytes = 0;
         int status = stbi_write_png(path, w, h, comp, result.data, stride_in_bytes);
         if (!status) {
             return error(env, "failed to write png");
         }
-    } else if (strcmp(extension, "bmp") == 0) {
+    } else if (strcmp(format, "bmp") == 0) {
         int status = stbi_write_bmp(path, w, h, comp, result.data);
         if (!status) {
             return error(env, "failed to write bmp");
         }
-    } else if (strcmp(extension, "tga") == 0) {
+    } else if (strcmp(format, "tga") == 0) {
         int status = stbi_write_tga(path, w, h, comp, result.data);
         if (!status) {
             return error(env, "failed to write tga");
         }
-    } else if (strcmp(extension, "jpg") == 0) {
+    } else if (strcmp(format, "jpg") == 0) {
         int quality = 100;
         int status = stbi_write_jpg(path, w, h, comp, result.data, quality);
         if (!status) {
             return error(env, "failed to write jpg");
         }
     } else {
-        return error(env, "wrong extension");
+        return error(env, "wrong format");
     }
 
     return enif_make_atom(env, "ok");
@@ -332,15 +332,15 @@ static void finalize_write(WriteContext *context, ErlNifEnv *env, ERL_NIF_TERM *
 
 static ERL_NIF_TERM to_binary(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     if (argc != 5) {
-        return error(env, "expecting 5 arguments: extension, data, height, width, and number of channels");
+        return error(env, "expecting 5 arguments: format, data, height, width, and number of channels");
     }
 
-    char extension[MAX_EXTNAME_LENGTH];
+    char format[MAX_EXTNAME_LENGTH];
     ErlNifBinary img;
     int w, h, comp;
 
-    if (!enif_get_atom(env, argv[0], extension, sizeof(extension), ERL_NIF_LATIN1)) {
-        return error(env, "invalid extension");
+    if (!enif_get_atom(env, argv[0], format, sizeof(format), ERL_NIF_LATIN1)) {
+        return error(env, "invalid format");
     }
     if (!enif_inspect_binary(env, argv[1], &img)) {
         return error(env, "invalid binary data");
@@ -360,26 +360,26 @@ static ERL_NIF_TERM to_binary(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
     WriteContext context = { .head = NULL, .last = NULL, .size = 0, .out_of_memory = false };
     ERL_NIF_TERM binary;
 
-    if (strcmp(extension, "png") == 0) {
+    if (strcmp(format, "png") == 0) {
         int stride_in_bytes = 0;
         int status = stbi_write_png_to_func(write_chunk, (void*) &context, w, h, comp, img.data, stride_in_bytes);
         finalize_write(&context, env, &binary);
         if (!status) {
             return error(env, "failed to write png");
         }
-    } else if (strcmp(extension, "bmp") == 0) {
+    } else if (strcmp(format, "bmp") == 0) {
         int status = stbi_write_bmp_to_func(write_chunk, (void*) &context, w, h, comp, img.data);
         finalize_write(&context, env, &binary);
         if (!status) {
             return error(env, "failed to write bmp");
         }
-    } else if (strcmp(extension, "tga") == 0) {
+    } else if (strcmp(format, "tga") == 0) {
         int status = stbi_write_tga_to_func(write_chunk, (void*) &context, w, h, comp, img.data);
         finalize_write(&context, env, &binary);
         if (!status) {
             return error(env, "failed to write tga");
         }
-    } else if (strcmp(extension, "jpg") == 0) {
+    } else if (strcmp(format, "jpg") == 0) {
         int quality = 100;
         int status = stbi_write_jpg_to_func(write_chunk, (void*) &context, w, h, comp, img.data, quality);
         finalize_write(&context, env, &binary);
@@ -387,7 +387,7 @@ static ERL_NIF_TERM to_binary(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
             return error(env, "failed to write jpg");
         }
     } else {
-        return error(env, "wrong extension");
+        return error(env, "wrong format");
     }
 
     if (context.out_of_memory) {

--- a/c_src/stb_image_nif.c
+++ b/c_src/stb_image_nif.c
@@ -39,27 +39,24 @@ static ERL_NIF_TERM pack_data(ErlNifEnv *env, unsigned char *data, int x, int y,
                                     enif_make_atom(env, type),
                                     enif_make_atom(env, channels));
         } else {
-            return enif_make_tuple2(env,
-                                    enif_make_atom(env, "error"),
-                                    enif_make_string(env, "out of memory", ERL_NIF_LATIN1));
+            return error(env, "out of memory");
         }
     } else {
-        return enif_make_tuple2(env,
-                                enif_make_atom(env, "error"),
-                                enif_make_string(env, "cannot decode image", ERL_NIF_LATIN1));
+        return error(env, "cannot decode image");
     }
 }
 
 static ERL_NIF_TERM from_file(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     if (argc != 3) {
-        return error(env, "expecting 3 arguments: filename, desired_channels, type");
+        return error(env, "expecting 3 arguments: path, desired_channels, type");
     }
-    char type[MAX_TYPE_LENGTH];
-    char filename[MAX_NAME_LENGTH];
-    int desired_channels = 0;
 
-    if (!enif_get_string(env, argv[0], filename, sizeof(filename), ERL_NIF_LATIN1)) {
-        return error(env, "invalid filename");
+    char type[MAX_TYPE_LENGTH];
+    char path[MAX_NAME_LENGTH];
+    int desired_channels;
+
+    if (!enif_get_string(env, argv[0], path, sizeof(path), ERL_NIF_LATIN1)) {
+        return error(env, "invalid path");
     }
 
     if(!enif_get_int(env, argv[1], &desired_channels)) {
@@ -74,13 +71,13 @@ static ERL_NIF_TERM from_file(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
     int x, y, n;
     unsigned char *data;
     if (strcmp(type, "u8") == 0) {
-        data = (unsigned char *)stbi_load(filename, &x, &y, &n, desired_channels);
+        data = (unsigned char *)stbi_load(path, &x, &y, &n, desired_channels);
         bytes_per_channel = sizeof(unsigned char);
     } else if (strcmp(type, "u16") == 0) {
-        data = (unsigned char *)stbi_load_16(filename, &x, &y, &n, desired_channels);
+        data = (unsigned char *)stbi_load_16(path, &x, &y, &n, desired_channels);
         bytes_per_channel = sizeof(unsigned char);
     } else if (strcmp(type, "f32") == 0) {
-        data = (unsigned char *)stbi_loadf(filename, &x, &y, &n, desired_channels);
+        data = (unsigned char *)stbi_loadf(path, &x, &y, &n, desired_channels);
         bytes_per_channel = sizeof(float);
     } else {
         return error(env, "invalid type");
@@ -91,18 +88,19 @@ static ERL_NIF_TERM from_file(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
     return ret;
 }
 
-static ERL_NIF_TERM from_memory(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+static ERL_NIF_TERM from_binary(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     if (argc != 3) {
-        return error(env, "expecting 3 arguments: buffer, desired_channels, type");
+        return error(env, "expecting 3 arguments: binary, desired_channels, type");
     }
-    ErlNifBinary result;
-    int desired_channels = 0;
+
+    ErlNifBinary binary;
+    int desired_channels;
     char type[MAX_NAME_LENGTH];
     int x, y, n;
     unsigned char *data;
 
-    if (!enif_inspect_binary(env, argv[0], &result)) {
-        return error(env, "invalid buffer");
+    if (!enif_inspect_binary(env, argv[0], &binary)) {
+        return error(env, "invalid binary");
     }
 
     if(!enif_get_int(env, argv[1], &desired_channels)) {
@@ -116,13 +114,13 @@ static ERL_NIF_TERM from_memory(ErlNifEnv *env, int argc, const ERL_NIF_TERM arg
     int bytes_per_channel;
 
     if (strcmp(type, "u8") == 0) {
-        data = (unsigned char *)stbi_load_from_memory(result.data, (int)result.size, &x, &y, &n, desired_channels);
+        data = (unsigned char *)stbi_load_from_memory(binary.data, (int)binary.size, &x, &y, &n, desired_channels);
         bytes_per_channel = sizeof(unsigned char);
     } else if (strcmp(type, "u16") == 0) {
-        data = (unsigned char *)stbi_load_16_from_memory(result.data, (int)result.size, &x, &y, &n, desired_channels);
+        data = (unsigned char *)stbi_load_16_from_memory(binary.data, (int)binary.size, &x, &y, &n, desired_channels);
         bytes_per_channel = sizeof(unsigned char);
     } else if (strcmp(type, "f32") == 0) {
-        data = (unsigned char *)stbi_loadf_from_memory(result.data, (int)result.size, &x, &y, &n, desired_channels);
+        data = (unsigned char *)stbi_loadf_from_memory(binary.data, (int)binary.size, &x, &y, &n, desired_channels);
         bytes_per_channel = sizeof(float);
     } else {
         return error(env, "invalid type");
@@ -133,27 +131,27 @@ static ERL_NIF_TERM from_memory(ErlNifEnv *env, int argc, const ERL_NIF_TERM arg
     return ret;
 }
 
-static ERL_NIF_TERM gif_from_memory(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+static ERL_NIF_TERM gif_from_binary(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     if (argc != 1) {
-        return error(env, "expecting 1 argument: buffer");
+        return error(env, "expecting 1 argument: binary");
     }
-    ErlNifBinary result;
-    if (enif_inspect_binary(env, argv[0], &result)) {
+
+    ErlNifBinary binary;
+
+    if (enif_inspect_binary(env, argv[0], &binary)) {
         int x, y, z, comp;
         int *delays = NULL;
         unsigned char *data = NULL;
         // the parameter req_comp (the last one) seems to be not in use, see stb_image.h:6706
-        data = stbi_load_gif_from_memory(result.data, (int)result.size, &delays, &x, &y, &z, &comp, 0);
+        data = stbi_load_gif_from_memory(binary.data, (int)binary.size, &delays, &x, &y, &z, &comp, 0);
         if (!data) {
-            return enif_make_tuple2(env,
-                                    enif_make_atom(env, "error"),
-                                    enif_make_string(env, "cannot decode the given GIF file", ERL_NIF_LATIN1));
+            return error(env, "cannot decode the given GIF file");
         }
 
         ERL_NIF_TERM *delays_term = (ERL_NIF_TERM *)malloc(sizeof(ERL_NIF_TERM) * z);
         ERL_NIF_TERM *frames_term = (ERL_NIF_TERM *)malloc(sizeof(ERL_NIF_TERM) * z);
         ErlNifBinary *frames_result = (ErlNifBinary *)malloc(sizeof(ErlNifBinary) * z);
-        ;
+
         bool ok = true;
         unsigned char *start = data;
         size_t offset = x * y * sizeof(unsigned char);
@@ -180,9 +178,7 @@ static ERL_NIF_TERM gif_from_memory(ErlNifEnv *env, int argc, const ERL_NIF_TERM
             free((void *)delays_term);
             free((void *)frames_result);
             free((void *)delays);
-            return enif_make_tuple2(env,
-                                    enif_make_atom(env, "error"),
-                                    enif_make_string(env, "out of memory", ERL_NIF_LATIN1));
+            return error(env, "out of memory");
         }
 
         ERL_NIF_TERM frames_ret = enif_make_list_from_array(env, frames_term, z);
@@ -208,15 +204,15 @@ static ERL_NIF_TERM gif_from_memory(ErlNifEnv *env, int argc, const ERL_NIF_TERM
 
 static ERL_NIF_TERM to_file(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     if (argc != 6) {
-        return error(env, "expecting 6 arguments: filename, extension, data, height, width, and number of channels");
+        return error(env, "expecting 6 arguments: path, extension, data, height, width, and number of channels");
     }
 
-    char filename[MAX_NAME_LENGTH], extension[MAX_EXTNAME_LENGTH];
+    char path[MAX_NAME_LENGTH], extension[MAX_EXTNAME_LENGTH];
     ErlNifBinary result;
     int w, h, comp;
 
-    if (!enif_get_string(env, argv[0], filename, sizeof(filename), ERL_NIF_LATIN1)) {
-        return error(env, "invalid filename");
+    if (!enif_get_string(env, argv[0], path, sizeof(path), ERL_NIF_LATIN1)) {
+        return error(env, "invalid path");
     }
     if (!enif_get_atom(env, argv[1], extension, sizeof(extension), ERL_NIF_LATIN1)) {
         return error(env, "invalid extension");
@@ -236,25 +232,25 @@ static ERL_NIF_TERM to_file(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 
     if (strcmp(extension, "png") == 0) {
         int stride_in_bytes = 0;
-        int status = stbi_write_png(filename, w, h, comp, result.data, stride_in_bytes);
+        int status = stbi_write_png(path, w, h, comp, result.data, stride_in_bytes);
         if (!status) {
-            return error(env, "filed to write png");
+            return error(env, "failed to write png");
         }
     } else if (strcmp(extension, "bmp") == 0) {
-        int status = stbi_write_bmp(filename, w, h, comp, result.data);
+        int status = stbi_write_bmp(path, w, h, comp, result.data);
         if (!status) {
-            return error(env, "filed to write bmp");
+            return error(env, "failed to write bmp");
         }
     } else if (strcmp(extension, "tga") == 0) {
-        int status = stbi_write_tga(filename, w, h, comp, result.data);
+        int status = stbi_write_tga(path, w, h, comp, result.data);
         if (!status) {
-            return error(env, "filed to write tga");
+            return error(env, "failed to write tga");
         }
     } else if (strcmp(extension, "jpg") == 0) {
         int quality = 100;
-        int status = stbi_write_jpg(filename, w, h, comp, result.data, quality);
+        int status = stbi_write_jpg(path, w, h, comp, result.data, quality);
         if (!status) {
-            return error(env, "filed to write jpg");
+            return error(env, "failed to write jpg");
         }
     } else {
         return error(env, "wrong extension");
@@ -309,9 +305,9 @@ static void write_chunk(void *context_, void *data, int size) {
     context->size += size;
 }
 
-static void finalize_write(WriteContext *context, ErlNifEnv *env, ERL_NIF_TERM *result) {
+static void finalize_write(WriteContext *context, ErlNifEnv *env, ERL_NIF_TERM *binary) {
     if (!context->out_of_memory) {
-        void *buffer = enif_make_new_binary(env, context->size, result);
+        void *buffer = enif_make_new_binary(env, context->size, binary);
 
         if (buffer == NULL) {
             context->out_of_memory = true;
@@ -334,7 +330,7 @@ static void finalize_write(WriteContext *context, ErlNifEnv *env, ERL_NIF_TERM *
     }
 }
 
-static ERL_NIF_TERM to_memory(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+static ERL_NIF_TERM to_binary(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     if (argc != 5) {
         return error(env, "expecting 5 arguments: extension, data, height, width, and number of channels");
     }
@@ -362,33 +358,33 @@ static ERL_NIF_TERM to_memory(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
     // The write_chunk function is called multiple times with subsequent
     // data chunks, we create a list of those and join afterwards
     WriteContext context = { .head = NULL, .last = NULL, .size = 0, .out_of_memory = false };
-    ERL_NIF_TERM result;
+    ERL_NIF_TERM binary;
 
     if (strcmp(extension, "png") == 0) {
         int stride_in_bytes = 0;
         int status = stbi_write_png_to_func(write_chunk, (void*) &context, w, h, comp, img.data, stride_in_bytes);
-        finalize_write(&context, env, &result);
+        finalize_write(&context, env, &binary);
         if (!status) {
-            return error(env, "filed to write png");
+            return error(env, "failed to write png");
         }
     } else if (strcmp(extension, "bmp") == 0) {
         int status = stbi_write_bmp_to_func(write_chunk, (void*) &context, w, h, comp, img.data);
-        finalize_write(&context, env, &result);
+        finalize_write(&context, env, &binary);
         if (!status) {
-            return error(env, "filed to write bmp");
+            return error(env, "failed to write bmp");
         }
     } else if (strcmp(extension, "tga") == 0) {
         int status = stbi_write_tga_to_func(write_chunk, (void*) &context, w, h, comp, img.data);
-        finalize_write(&context, env, &result);
+        finalize_write(&context, env, &binary);
         if (!status) {
-            return error(env, "filed to write tga");
+            return error(env, "failed to write tga");
         }
     } else if (strcmp(extension, "jpg") == 0) {
         int quality = 100;
         int status = stbi_write_jpg_to_func(write_chunk, (void*) &context, w, h, comp, img.data, quality);
-        finalize_write(&context, env, &result);
+        finalize_write(&context, env, &binary);
         if (!status) {
-            return error(env, "filed to write jpg");
+            return error(env, "failed to write jpg");
         }
     } else {
         return error(env, "wrong extension");
@@ -398,7 +394,7 @@ static ERL_NIF_TERM to_memory(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
         return error(env, "out of memory");
     }
 
-    return enif_make_tuple2(env, enif_make_atom(env, "ok"), result);
+    return enif_make_tuple2(env, enif_make_atom(env, "ok"), binary);
 }
 
 static int on_load(ErlNifEnv *env, void **_sth1, ERL_NIF_TERM _sth2) {
@@ -415,10 +411,10 @@ static int on_upgrade(ErlNifEnv *_sth0, void **_sth1, void **_sth2, ERL_NIF_TERM
 
 static ErlNifFunc nif_functions[] = {
     {"from_file", 3, from_file, ERL_NIF_DIRTY_JOB_IO_BOUND},
-    {"from_memory", 3, from_memory, ERL_NIF_DIRTY_JOB_CPU_BOUND},
-    {"gif_from_memory", 1, gif_from_memory, ERL_NIF_DIRTY_JOB_CPU_BOUND},
+    {"from_binary", 3, from_binary, ERL_NIF_DIRTY_JOB_CPU_BOUND},
+    {"gif_from_binary", 1, gif_from_binary, ERL_NIF_DIRTY_JOB_CPU_BOUND},
     {"to_file", 6, to_file, ERL_NIF_DIRTY_JOB_IO_BOUND},
-    {"to_memory", 5, to_memory, ERL_NIF_DIRTY_JOB_CPU_BOUND}};
+    {"to_binary", 5, to_binary, ERL_NIF_DIRTY_JOB_CPU_BOUND}};
 
 ERL_NIF_INIT(Elixir.StbImage.Nif, nif_functions, on_load, on_reload, on_upgrade, NULL);
 

--- a/lib/stb_image.ex
+++ b/lib/stb_image.ex
@@ -17,8 +17,10 @@ defmodule StbImage do
   There are also specific functions for working with GIFs.
   """
 
+  defguardp is_path(path) when is_binary(path) or is_list(path)
+
   @doc """
-  Decodes image at the given `filename`.
+  Decodes image from file at `path`.
 
   ## Options
 
@@ -38,16 +40,14 @@ defmodule StbImage do
       {h, w, c} = shape
 
   """
-  def from_file(filename, opts \\ [])
-      when (is_binary(filename) or is_list(filename)) and is_list(opts) do
-    filename = if is_binary(filename), do: String.to_charlist(filename), else: filename
+  def from_file(path, opts \\ []) when is_path(path) and is_list(opts) do
     type = opts[:type] || :u8
     channels = opts[:channels] || 0
-    StbImage.Nif.from_file(filename, channels, type)
+    StbImage.Nif.from_file(path_to_charlist(path), channels, type)
   end
 
   @doc """
-  Decodes image from `buffer` in memory.
+  Decodes image from `binary`.
 
   ## Options
 
@@ -60,7 +60,7 @@ defmodule StbImage do
   ## Example
 
       {:ok, buffer} = File.read("/path/to/image")
-      {:ok, img, shape, type, channels} = StbImage.from_memory(buffer)
+      {:ok, img, shape, type, channels} = StbImage.from_binary(buffer)
       {h, w, c} = shape
 
       # If you know the image is a 4-channel image and auto-detection failed
@@ -68,14 +68,14 @@ defmodule StbImage do
       {h, w, c} = shape
 
   """
-  def from_memory(buffer, opts \\ []) when is_binary(buffer) and is_list(opts) do
+  def from_binary(buffer, opts \\ []) when is_binary(buffer) and is_list(opts) do
     type = opts[:type] || :u8
     channels = opts[:channels] || 0
-    StbImage.Nif.from_memory(buffer, channels, type)
+    StbImage.Nif.from_binary(buffer, channels, type)
   end
 
   @doc """
-  Decodes GIF image from `filename`.
+  Decodes GIF image from file at `path`.
 
   ## Example
 
@@ -86,90 +86,105 @@ defmodule StbImage do
       # delays is a list that has n elements, where n is the number of frames
 
   """
-  def gif_from_file(filename) when is_binary(filename) or is_list(filename) do
-    with {:ok, buffer} <- File.read(filename) do
-      gif_from_memory(buffer)
+  def gif_from_file(path) when is_binary(path) or is_list(path) do
+    with {:ok, binary} <- File.read(path) do
+      gif_from_binary(binary)
     end
   end
 
   @doc """
-  Decodes GIF image from `buffer` in memory.
+  Decodes GIF image from `binary`.
 
   ## Example
 
       {:ok, buffer} = File.read("/path/to/image")
-      {:ok, frames, shape, delays} = StbImage.gif_from_memory(buffer)
+      {:ok, frames, shape, delays} = StbImage.gif_from_binary(buffer)
       {h, w, 3} = shape
 
       # GIFs always have channels == :rgb and type == :u8
       # delays is a list that has n elements, where n is the number of frames
 
   """
-  def gif_from_memory(buffer) when is_binary(buffer), do: StbImage.Nif.gif_from_memory(buffer)
+  def gif_from_binary(binary) when is_binary(binary), do: StbImage.Nif.gif_from_binary(binary)
 
-  @to_file_exts ~w(jpg png bmp tga)a
+  @encoding_formats ~w(jpg png bmp tga)a
+  @encoding_formats_string Enum.map_join(@encoding_formats, ", ", &inspect/1)
 
   @doc """
-  Saves image to `filename`.
+  Saves image to the file at `path`.
 
-  The format of the file is taken to the filename extension.
-  Only .jpg, .png, .bmp, and .tga are supported. You can also
-  pass the `:extension` as an atom option.
+  The supported formats are #{@encoding_formats_string}.
 
-  This function also requires the `height`, `width`, and
-  number of `channels` to be given.
+  The format is determined from the file extension if possible,
+  you can also pass it explicitly via the `:format` option.
 
-  Returns `:ok` if suceeds.
+  Returns `:ok` on success and `{:error, reason}` otherwise.
 
-  Make sure the directory you intent to write the file to
-  exists, otherwise it will return an `{:error, reason}`
-  tuple.
+  Make sure the directory you intent to write the file to exists,
+  otherwise an error is returned.
+
+  ## Options
+
+    * `:format` - one of the supported image formats
+
   """
-  def to_file(filename, data, height, width, channels, opts \\ [])
-      when is_binary(data) and is_integer(width) and width > 0 and is_integer(height) and
-             height > 0 and is_integer(channels) and channels > 0 and
+  def to_file(path, data, height, width, channels, opts \\ [])
+      when is_path(path) and is_binary(data) and is_integer(width) and width > 0 and
+             is_integer(height) and height > 0 and is_integer(channels) and channels > 0 and
              is_list(opts) do
-    extension = opts[:extension] || extname!(filename)
-
-    if extension not in @to_file_exts do
-      badext!(extension)
-    end
-
-    filename = if is_binary(filename), do: String.to_charlist(filename), else: filename
-    StbImage.Nif.to_file(filename, extension, data, height, width, channels)
+    format = opts[:format] || format_from_path!(path)
+    assert_encoding_format!(format)
+    StbImage.Nif.to_file(path_to_charlist(path), format, data, height, width, channels)
   end
 
   @doc """
-  Encodes image to an in-memory binary.
+  Encodes image to a binary.
+
+  The supported formats are #{@encoding_formats_string}.
 
   ## Example
 
-      {:ok, buffer} = StbImage.to_memory(:png, img, height, width, channels)
+      {:ok, binary} = StbImage.to_binary(:png, img, height, width, channels)
 
   """
-  def to_memory(extension, data, height, width, channels)
-      when is_binary(data) and is_integer(width) and width > 0 and is_integer(height) and
-             height > 0 and is_integer(channels) and channels > 0 do
-    if extension not in @to_file_exts do
-      badext!(extension)
+  def to_binary(format, data, height, width, channels)
+      when is_atom(format) and is_binary(data) and is_integer(width) and width > 0 and
+             is_integer(height) and height > 0 and is_integer(channels) and channels > 0 do
+    assert_encoding_format!(format)
+    StbImage.Nif.to_binary(format, data, height, width, channels)
+  end
+
+  defp format_from_path!(path) do
+    case Path.extname(path) do
+      ".jpg" ->
+        :jpg
+
+      ".jpeg" ->
+        :jpg
+
+      ".png" ->
+        :png
+
+      ".bmp" ->
+        :bmp
+
+      ".tga" ->
+        :tga
+
+      ext ->
+        raise "could not determine a supported encoding format for file #{inspect(path)} with extension #{inspect(ext)}, " <>
+                "please specify a supported :format option explicitly"
     end
-
-    StbImage.Nif.to_memory(extension, data, height, width, channels)
   end
 
-  defp extname!(filename) do
-    case Path.extname(filename) do
-      ".jpg" -> :jpg
-      ".png" -> :png
-      ".bmp" -> :bmp
-      ".tga" -> :tga
-      _ -> badext!(filename)
+  defp assert_encoding_format!(format) do
+    unless format in @encoding_formats do
+      raise ArgumentError,
+            "got an unsupported encoding format #{inspect(format)}, " <>
+              "the format must be one of #{inspect(@encoding_formats)}"
     end
   end
 
-  defp badext!(ext) do
-    raise ArgumentError,
-          "trying to save image to file with unsupported extension #{ext}. " <>
-            "Please set the :extension option to one of #{inspect(@to_file_exts)}"
-  end
+  defp path_to_charlist(path) when is_list(path), do: path
+  defp path_to_charlist(path) when is_binary(path), do: String.to_charlist(path)
 end

--- a/lib/stb_image.ex
+++ b/lib/stb_image.ex
@@ -59,7 +59,6 @@ defmodule StbImage do
 
   ## Example
 
-
       {:ok, buffer} = File.read("/path/to/image")
       {:ok, img, shape, type, channels} = StbImage.from_memory(buffer)
       {h, w, c} = shape
@@ -138,6 +137,24 @@ defmodule StbImage do
 
     filename = if is_binary(filename), do: String.to_charlist(filename), else: filename
     StbImage.Nif.to_file(filename, extension, data, height, width, channels)
+  end
+
+  @doc """
+  Encodes image to an in-memory binary.
+
+  ## Example
+
+      {:ok, buffer} = StbImage.to_memory(:png, img, height, width, channels)
+
+  """
+  def to_memory(extension, data, height, width, channels)
+      when is_binary(data) and is_integer(width) and width > 0 and is_integer(height) and
+             height > 0 and is_integer(channels) and channels > 0 do
+    if extension not in @to_file_exts do
+      badext!(extension)
+    end
+
+    StbImage.Nif.to_memory(extension, data, height, width, channels)
   end
 
   defp extname!(filename) do

--- a/lib/stb_image_nif.ex
+++ b/lib/stb_image_nif.ex
@@ -12,9 +12,12 @@ defmodule StbImage.Nif do
     end
   end
 
-  def from_file(_filename, _desired_channels, _type), do: :erlang.nif_error(:not_loaded)
-  def from_memory(_buffer, _desired_channels, _type), do: :erlang.nif_error(:not_loaded)
-  def gif_from_memory(_gif_filename), do: :erlang.nif_error(:not_loaded)
-  def to_file(_filename, _extension, _data, _width, _height, _channels), do: :erlang.nif_error(:not_loaded)
-  def to_memory(_extension, _data, _width, _height, _channels), do: :erlang.nif_error(:not_loaded)
+  def from_file(_path, _desired_channels, _type), do: :erlang.nif_error(:not_loaded)
+  def from_binary(_buffer, _desired_channels, _type), do: :erlang.nif_error(:not_loaded)
+  def gif_from_binary(_gif_path), do: :erlang.nif_error(:not_loaded)
+
+  def to_file(_path, _extension, _data, _width, _height, _channels),
+    do: :erlang.nif_error(:not_loaded)
+
+  def to_binary(_extension, _data, _width, _height, _channels), do: :erlang.nif_error(:not_loaded)
 end

--- a/lib/stb_image_nif.ex
+++ b/lib/stb_image_nif.ex
@@ -16,8 +16,8 @@ defmodule StbImage.Nif do
   def from_binary(_buffer, _desired_channels, _type), do: :erlang.nif_error(:not_loaded)
   def gif_from_binary(_gif_path), do: :erlang.nif_error(:not_loaded)
 
-  def to_file(_path, _extension, _data, _width, _height, _channels),
+  def to_file(_path, _format, _data, _width, _height, _channels),
     do: :erlang.nif_error(:not_loaded)
 
-  def to_binary(_extension, _data, _width, _height, _channels), do: :erlang.nif_error(:not_loaded)
+  def to_binary(_format, _data, _width, _height, _channels), do: :erlang.nif_error(:not_loaded)
 end

--- a/lib/stb_image_nif.ex
+++ b/lib/stb_image_nif.ex
@@ -16,4 +16,5 @@ defmodule StbImage.Nif do
   def from_memory(_buffer, _desired_channels, _type), do: :erlang.nif_error(:not_loaded)
   def gif_from_memory(_gif_filename), do: :erlang.nif_error(:not_loaded)
   def to_file(_filename, _extension, _data, _width, _height, _channels), do: :erlang.nif_error(:not_loaded)
+  def to_memory(_extension, _data, _width, _height, _channels), do: :erlang.nif_error(:not_loaded)
 end

--- a/test/stb_image_test.exs
+++ b/test/stb_image_test.exs
@@ -88,10 +88,10 @@ defmodule StbImageTest do
              [<<180, 128, 70, 255, 171, 119>>, <<61, 255, 65, 143, 117, 255>>]
   end
 
-  for ext <- ~w(bmp png tga jpg) do
+  for ext <- ~w(bmp png tga jpg)a do
     @ext ext
 
-    test "save image #{@ext}" do
+    test "save image #{@ext} to file" do
       read = StbImage.from_file(Path.join(__DIR__, "test.#{@ext}"))
       {:ok, img, {height, width, num_channels}, _, _} = read
       save_at = "tmp/save_test.#{@ext}"
@@ -103,6 +103,14 @@ defmodule StbImageTest do
       after
         File.rm!(save_at)
       end
+    end
+
+    test "encode image as #{@ext} in memory" do
+      {:ok, img, {height, width, num_channels}, _, _} =
+        read = StbImage.from_file(Path.join(__DIR__, "test.#{@ext}"))
+
+      {:ok, encoded} = StbImage.to_memory(@ext, img, height, width, num_channels)
+      assert StbImage.from_memory(encoded) == read
     end
   end
 end

--- a/test/stb_image_test.exs
+++ b/test/stb_image_test.exs
@@ -55,8 +55,8 @@ defmodule StbImageTest do
   end
 
   test "decode png from memory" do
-    {:ok, buffer} = File.read(Path.join(__DIR__, "test.png"))
-    {:ok, img, shape, type, channels} = StbImage.from_memory(buffer)
+    {:ok, binary} = File.read(Path.join(__DIR__, "test.png"))
+    {:ok, img, shape, type, channels} = StbImage.from_binary(binary)
     assert type == :u8
     assert shape == {2, 3, 4}
     assert channels == :rgba
@@ -67,8 +67,8 @@ defmodule StbImageTest do
   end
 
   test "decode jpg from memory" do
-    {:ok, buffer} = File.read(Path.join(__DIR__, "test.jpg"))
-    {:ok, img, shape, type, channels} = StbImage.from_memory(buffer)
+    {:ok, binary} = File.read(Path.join(__DIR__, "test.jpg"))
+    {:ok, img, shape, type, channels} = StbImage.from_binary(binary)
     assert type == :u8
     assert shape == {2, 3, 3}
     assert channels == :rgb
@@ -109,8 +109,8 @@ defmodule StbImageTest do
       {:ok, img, {height, width, num_channels}, _, _} =
         read = StbImage.from_file(Path.join(__DIR__, "test.#{@ext}"))
 
-      {:ok, encoded} = StbImage.to_memory(@ext, img, height, width, num_channels)
-      assert StbImage.from_memory(encoded) == read
+      {:ok, encoded} = StbImage.to_binary(@ext, img, height, width, num_channels)
+      assert StbImage.from_binary(encoded) == read
     end
   end
 end


### PR DESCRIPTION
Adds an in-memory counterpart of `StbImage.to_file/6`.