### PR TITLE
Use consistent names

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: 24.1.5
+          otp-version: 24.3
           elixir-version: 1.13.3
 
       - name: Install system dependecies

--- a/c_src/nif_utils.h
+++ b/c_src/nif_utils.h
@@ -2,7 +2,7 @@
 
 #include "erl_nif.h"
 
-ERL_NIF_TERM error(ErlNifEnv *env, const char *msg)
+static ERL_NIF_TERM error(ErlNifEnv *env, const char *msg)
 {
   ERL_NIF_TERM atom = enif_make_atom(env, "error");
   ERL_NIF_TERM msg_term = enif_make_string(env, msg, ERL_NIF_LATIN1);

--- a/c_src/nif_utils.h
+++ b/c_src/nif_utils.h
@@ -1,9 +1,10 @@
 #pragma once
 
 #include "erl_nif.h"
-  ERL_NIF_TERM error(ErlNifEnv *env, const char *msg)
-  {
-    ERL_NIF_TERM atom = enif_make_atom(env, "error");
-    ERL_NIF_TERM msg_term = enif_make_string(env, msg, ERL_NIF_LATIN1);
-    return enif_make_tuple2(env, atom, msg_term);
-  }
+
+ERL_NIF_TERM error(ErlNifEnv *env, const char *msg)
+{
+  ERL_NIF_TERM atom = enif_make_atom(env, "error");
+  ERL_NIF_TERM msg_term = enif_make_string(env, msg, ERL_NIF_LATIN1);
+  return enif_make_tuple2(env, atom, msg_term);
+}

--- a/c_src/stb_image_nif.c
+++ b/c_src/stb_image_nif.c
@@ -263,8 +263,8 @@ static void write_chunk(void *context_, void *data, int size) {
     void *chunk_data = enif_alloc(size);
 
     if (chunk == NULL || chunk_data == NULL) {
-        free(chunk);
-        free(chunk_data);
+        enif_free(chunk);
+        enif_free(chunk_data);
         context->out_of_memory = true;
         return;
     }

--- a/c_src/stb_image_nif.c
+++ b/c_src/stb_image_nif.c
@@ -45,7 +45,7 @@ static ERL_NIF_TERM pack_data(ErlNifEnv *env, unsigned char *data, int x, int y,
 
 static ERL_NIF_TERM read_file(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     if (argc != 2) {
-        return error(env, "expecting 3 arguments: path and desired_channels");
+        return error(env, "expecting 2 arguments: path and desired_channels");
     }
 
     char path[MAX_NAME_LENGTH];

--- a/c_src/stb_image_nif.c
+++ b/c_src/stb_image_nif.c
@@ -43,7 +43,7 @@ static ERL_NIF_TERM pack_data(ErlNifEnv *env, unsigned char *data, int x, int y,
     }
 }
 
-static ERL_NIF_TERM from_file(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+static ERL_NIF_TERM read_file(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     if (argc != 2) {
         return error(env, "expecting 3 arguments: path and desired_channels");
     }
@@ -77,7 +77,7 @@ static ERL_NIF_TERM from_file(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
     return ret;
 }
 
-static ERL_NIF_TERM from_binary(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+static ERL_NIF_TERM read_binary(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     if (argc != 2) {
         return error(env, "expecting 2 arguments: binary and desired_channels");
     }
@@ -107,7 +107,7 @@ static ERL_NIF_TERM from_binary(ErlNifEnv *env, int argc, const ERL_NIF_TERM arg
     return ret;
 }
 
-static ERL_NIF_TERM gif_from_binary(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+static ERL_NIF_TERM gif_read_binary(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     if (argc != 1) {
         return error(env, "expecting 1 argument: binary");
     }
@@ -177,7 +177,7 @@ static ERL_NIF_TERM gif_from_binary(ErlNifEnv *env, int argc, const ERL_NIF_TERM
     }
 }
 
-static ERL_NIF_TERM to_file(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+static ERL_NIF_TERM write_file(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     if (argc != 6) {
         return error(env, "expecting 6 arguments: path, format, data, height, width, and number of channels");
     }
@@ -449,10 +449,10 @@ static int on_upgrade(ErlNifEnv *_sth0, void **_sth1, void **_sth2, ERL_NIF_TERM
 }
 
 static ErlNifFunc nif_functions[] = {
-    {"from_file", 2, from_file, ERL_NIF_DIRTY_JOB_IO_BOUND},
-    {"from_binary", 2, from_binary, ERL_NIF_DIRTY_JOB_CPU_BOUND},
-    {"gif_from_binary", 1, gif_from_binary, ERL_NIF_DIRTY_JOB_CPU_BOUND},
-    {"to_file", 6, to_file, ERL_NIF_DIRTY_JOB_IO_BOUND},
+    {"read_file", 2, read_file, ERL_NIF_DIRTY_JOB_IO_BOUND},
+    {"read_binary", 2, read_binary, ERL_NIF_DIRTY_JOB_CPU_BOUND},
+    {"gif_read_binary", 1, gif_read_binary, ERL_NIF_DIRTY_JOB_CPU_BOUND},
+    {"write_file", 6, write_file, ERL_NIF_DIRTY_JOB_IO_BOUND},
     {"to_binary", 5, to_binary, ERL_NIF_DIRTY_JOB_CPU_BOUND},
     {"resize", 7, resize, ERL_NIF_DIRTY_JOB_CPU_BOUND}};
 

--- a/c_src/stb_image_nif.c
+++ b/c_src/stb_image_nif.c
@@ -107,7 +107,7 @@ static ERL_NIF_TERM read_binary(ErlNifEnv *env, int argc, const ERL_NIF_TERM arg
     return ret;
 }
 
-static ERL_NIF_TERM gif_read_binary(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
+static ERL_NIF_TERM read_gif_binary(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
     if (argc != 1) {
         return error(env, "expecting 1 argument: binary");
     }
@@ -451,7 +451,7 @@ static int on_upgrade(ErlNifEnv *_sth0, void **_sth1, void **_sth2, ERL_NIF_TERM
 static ErlNifFunc nif_functions[] = {
     {"read_file", 2, read_file, ERL_NIF_DIRTY_JOB_IO_BOUND},
     {"read_binary", 2, read_binary, ERL_NIF_DIRTY_JOB_CPU_BOUND},
-    {"gif_read_binary", 1, gif_read_binary, ERL_NIF_DIRTY_JOB_CPU_BOUND},
+    {"read_gif_binary", 1, read_gif_binary, ERL_NIF_DIRTY_JOB_CPU_BOUND},
     {"write_file", 6, write_file, ERL_NIF_DIRTY_JOB_IO_BOUND},
     {"to_binary", 5, to_binary, ERL_NIF_DIRTY_JOB_CPU_BOUND},
     {"resize", 7, resize, ERL_NIF_DIRTY_JOB_CPU_BOUND}};

--- a/lib/stb_image.ex
+++ b/lib/stb_image.ex
@@ -161,7 +161,7 @@ defmodule StbImage do
       img = img.data
 
       # If you know the image is a 4-channel image and auto-detection failed
-      {:ok, img} = StbImage.read_file("/path/to/image", channels: 4)
+      {:ok, img} = StbImage.from_binary(buffer, channels: 4)
       {h, w, c} = img.shape
       img = img.data
 

--- a/lib/stb_image.ex
+++ b/lib/stb_image.ex
@@ -193,14 +193,14 @@ defmodule StbImage do
 
   ## Example
 
-      {:ok, frames, delays} = StbImage.gif_read_file("/path/to/image")
+      {:ok, frames, delays} = StbImage.read_gif_file("/path/to/image")
       frame = Enum.at(frames, 0)
       {h, w, 3} = frame.shape
 
   """
-  def gif_read_file(path) when is_binary(path) or is_list(path) do
+  def read_gif_file(path) when is_binary(path) or is_list(path) do
     with {:ok, binary} <- File.read(path) do
-      gif_read_binary(binary)
+      read_gif_binary(binary)
     end
   end
 
@@ -210,13 +210,13 @@ defmodule StbImage do
   ## Example
 
       {:ok, buffer} = File.read("/path/to/image")
-      {:ok, frames, delays} = StbImage.gif_read_binary(buffer)
+      {:ok, frames, delays} = StbImage.read_gif_binary(buffer)
       frame = Enum.at(frames, 0)
       {h, w, 3} = frame.shape
 
   """
-  def gif_read_binary(binary) when is_binary(binary) do
-    with {:ok, frames, shape, delays} <- StbImage.Nif.gif_read_binary(binary) do
+  def read_gif_binary(binary) when is_binary(binary) do
+    with {:ok, frames, shape, delays} <- StbImage.Nif.read_gif_binary(binary) do
       stb_frames = for frame <- frames, do: %StbImage{data: frame, shape: shape, type: {:u, 8}}
 
       {:ok, stb_frames, delays}

--- a/lib/stb_image_nif.ex
+++ b/lib/stb_image_nif.ex
@@ -18,7 +18,7 @@ defmodule StbImage.Nif do
   def read_binary(_buffer, _desired_channels),
     do: :erlang.nif_error(:not_loaded)
 
-  def gif_read_binary(_gif_path),
+  def read_gif_binary(_gif_path),
     do: :erlang.nif_error(:not_loaded)
 
   def write_file(_path, _format, _data, _height, _width, _channels),

--- a/lib/stb_image_nif.ex
+++ b/lib/stb_image_nif.ex
@@ -12,16 +12,16 @@ defmodule StbImage.Nif do
     end
   end
 
-  def from_file(_path, _desired_channels),
+  def read_file(_path, _desired_channels),
     do: :erlang.nif_error(:not_loaded)
 
-  def from_binary(_buffer, _desired_channels),
+  def read_binary(_buffer, _desired_channels),
     do: :erlang.nif_error(:not_loaded)
 
-  def gif_from_binary(_gif_path),
+  def gif_read_binary(_gif_path),
     do: :erlang.nif_error(:not_loaded)
 
-  def to_file(_path, _format, _data, _height, _width, _channels),
+  def write_file(_path, _format, _data, _height, _width, _channels),
     do: :erlang.nif_error(:not_loaded)
 
   def to_binary(_format, _data, _height, _width, _channels),

--- a/test/stb_image_test.exs
+++ b/test/stb_image_test.exs
@@ -84,7 +84,7 @@ defmodule StbImageTest do
   end
 
   test "decode gif" do
-    {:ok, frames, delays} = StbImage.gif_read_file(Path.join(__DIR__, "test.gif"))
+    {:ok, frames, delays} = StbImage.read_gif_file(Path.join(__DIR__, "test.gif"))
     assert delays == [200, 200]
 
     assert Enum.all?(frames, &(&1.type == {:u, 8}))

--- a/test/stb_image_test.exs
+++ b/test/stb_image_test.exs
@@ -4,7 +4,7 @@ defmodule StbImageTest do
   doctest StbImage
 
   test "decode png from file" do
-    {:ok, img} = StbImage.from_file(Path.join(__DIR__, "test.png"))
+    img = StbImage.read_file!(Path.join(__DIR__, "test.png"))
     assert img.type == {:u, 8}
     assert img.shape == {2, 3, 4}
 
@@ -19,7 +19,7 @@ defmodule StbImageTest do
   end
 
   test "decode jpg from file" do
-    {:ok, img} = StbImage.from_file(Path.join(__DIR__, "test.jpg"))
+    img = StbImage.read_file!(Path.join(__DIR__, "test.jpg"))
     assert img.type == {:u, 8}
     assert img.shape == {2, 3, 3}
 
@@ -34,7 +34,7 @@ defmodule StbImageTest do
   end
 
   test "decode hdr from file" do
-    {:ok, img} = StbImage.from_file(Path.join(__DIR__, "test.hdr"))
+    img = StbImage.read_file!(Path.join(__DIR__, "test.hdr"))
     assert img.type == {:f, 32}
     assert img.shape == {384, 768, 3}
     assert is_binary(img.data)
@@ -46,7 +46,7 @@ defmodule StbImageTest do
 
   test "decode png from memory" do
     {:ok, binary} = File.read(Path.join(__DIR__, "test.png"))
-    {:ok, img} = StbImage.from_binary(binary)
+    img = StbImage.read_binary!(binary)
     assert img.type == {:u, 8}
     assert img.shape == {2, 3, 4}
 
@@ -60,7 +60,7 @@ defmodule StbImageTest do
 
   test "decode jpg from memory" do
     {:ok, binary} = File.read(Path.join(__DIR__, "test.jpg"))
-    {:ok, img} = StbImage.from_binary(binary)
+    img = StbImage.read_binary!(binary)
     assert img.type == {:u, 8}
     assert img.shape == {2, 3, 3}
 
@@ -74,7 +74,7 @@ defmodule StbImageTest do
 
   test "decode hdr from memory" do
     {:ok, binary} = File.read(Path.join(__DIR__, "test.hdr"))
-    {:ok, img} = StbImage.from_binary(binary)
+    img = StbImage.read_binary!(binary)
     assert img.type == {:f, 32}
     assert img.shape == {384, 768, 3}
     assert is_binary(img.data)
@@ -84,7 +84,7 @@ defmodule StbImageTest do
   end
 
   test "decode gif" do
-    {:ok, frames, delays} = StbImage.gif_from_file(Path.join(__DIR__, "test.gif"))
+    {:ok, frames, delays} = StbImage.gif_read_file(Path.join(__DIR__, "test.gif"))
     assert delays == [200, 200]
 
     assert Enum.all?(frames, & &1.type == {:u, 8})
@@ -98,49 +98,67 @@ defmodule StbImageTest do
     @ext ext
 
     test "decode #{@ext} from file matches decode from binary" do
-      {:ok, img} = StbImage.from_file(Path.join(__DIR__, "test.#{@ext}"))
-      assert StbImage.from_binary(File.read!(Path.join(__DIR__, "test.#{@ext}"))) == {:ok, img}
+      img = StbImage.read_file!(Path.join(__DIR__, "test.#{@ext}"))
+      assert StbImage.read_binary(File.read!(Path.join(__DIR__, "test.#{@ext}"))) == {:ok, img}
     end
 
     test "decode #{@ext} from file and encode to file" do
-      {:ok, img} = StbImage.from_file(Path.join(__DIR__, "test.#{@ext}"))
+      img = StbImage.read_file!(Path.join(__DIR__, "test.#{@ext}"))
       save_at = "tmp/save_test.#{@ext}"
 
       try do
         File.mkdir_p!("tmp")
-        :ok = StbImage.to_file(img, save_at)
-        assert StbImage.from_file(save_at) == {:ok, img}
+        :ok = StbImage.write_file!(img, save_at)
+        assert StbImage.read_file(save_at) == {:ok, img}
       after
         File.rm!(save_at)
       end
     end
 
     test "decode #{@ext} from file and encode to binary" do
-      {:ok, img} = StbImage.from_file(Path.join(__DIR__, "test.#{@ext}"))
+      img = StbImage.read_file!(Path.join(__DIR__, "test.#{@ext}"))
 
-      {:ok, encoded} = StbImage.to_binary(img, @ext)
-      assert StbImage.from_binary(encoded) == {:ok, img}
+      encoded = StbImage.to_binary(img, @ext)
+      assert StbImage.read_binary(encoded) == {:ok, img}
     end
   end
 
   test "resize png" do
-    {:ok, img} = StbImage.from_file(Path.join(__DIR__, "test.png"))
-    {:ok, resized_img} = StbImage.resize(img, 4, 6)
+    img = StbImage.read_file!(Path.join(__DIR__, "test.png"))
+    resized_img = StbImage.resize(img, 4, 6)
     assert resized_img.shape == {4, 6, 4}
     assert resized_img.type == img.type
   end
 
   test "resize jpg" do
-    {:ok, img} = StbImage.from_file(Path.join(__DIR__, "test.jpg"))
-    {:ok, resized_img} = StbImage.resize(img, 4, 6)
+    img = StbImage.read_file!(Path.join(__DIR__, "test.jpg"))
+    resized_img = StbImage.resize(img, 4, 6)
     assert resized_img.shape == {4, 6, 3}
     assert resized_img.type == img.type
   end
 
   test "resize hdr" do
-    {:ok, img} = StbImage.from_file(Path.join(__DIR__, "test.hdr"))
-    {:ok, resized_img} = StbImage.resize(img, 192, 384)
+    img = StbImage.read_file!(Path.join(__DIR__, "test.hdr"))
+    resized_img = StbImage.resize(img, 192, 384)
     assert resized_img.shape == {192, 384, 3}
     assert resized_img.type == img.type
+  end
+
+  describe "errors" do
+    test "read_file" do
+      assert StbImage.read_file("unknown.jpg") == {:error, "could not open file"}
+
+      assert_raise ArgumentError, "could not open file", fn ->
+        StbImage.read_file!("unknown.jpg")
+      end
+    end
+
+    test "read_binary" do
+      assert StbImage.read_binary("") == {:error, "cannot decode image"}
+
+      assert_raise ArgumentError, "cannot decode image", fn ->
+        StbImage.read_binary!("")
+      end
+    end
   end
 end

--- a/test/stb_image_test.exs
+++ b/test/stb_image_test.exs
@@ -87,8 +87,8 @@ defmodule StbImageTest do
     {:ok, frames, delays} = StbImage.gif_read_file(Path.join(__DIR__, "test.gif"))
     assert delays == [200, 200]
 
-    assert Enum.all?(frames, & &1.type == {:u, 8})
-    assert Enum.all?(frames, & &1.shape == {2, 3, 3})
+    assert Enum.all?(frames, &(&1.type == {:u, 8}))
+    assert Enum.all?(frames, &(&1.shape == {2, 3, 3}))
 
     assert Enum.map(frames, & &1.data) ==
              [<<180, 128, 70, 255, 171, 119>>, <<61, 255, 65, 143, 117, 255>>]


### PR DESCRIPTION
  * read/write for operations that return ok/error
  * from/to for operations that are direct conversions