### PR TITLE
Use erlang internal memory allocators

### DIFF
--- a/c_src/stb_image_nif.c
+++ b/c_src/stb_image_nif.c
@@ -152,10 +152,10 @@ static ERL_NIF_TERM read_gif_binary(ErlNifEnv *env, int argc, const ERL_NIF_TERM
 
         if (!ok) {
             STBI_FREE((void *)data);
+            STBI_FREE((void *)delays);
             enif_free((void *)frames_term);
             enif_free((void *)delays_term);
             enif_free((void *)frames_result);
-            enif_free((void *)delays);
             return error(env, "out of memory");
         }
 
@@ -170,10 +170,10 @@ static ERL_NIF_TERM read_gif_binary(ErlNifEnv *env, int argc, const ERL_NIF_TERM
                                                                  enif_make_int(env, 3)),
                                                 delays_ret);
         STBI_FREE((void *)data);
+        STBI_FREE((void *)delays);
         enif_free((void *)frames_term);
         enif_free((void *)delays_term);
         enif_free((void *)frames_result);
-        enif_free((void *)delays);
         return ret_val;
     } else {
         return enif_make_badarg(env);

--- a/c_src/stb_image_nif.c
+++ b/c_src/stb_image_nif.c
@@ -5,31 +5,7 @@
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #define STB_IMAGE_RESIZE_IMPLEMENTATION
 #define STBI_MALLOC enif_alloc
-static void * nif_realloc(void *ptr, size_t oldsz, size_t newsz) {
-    // follow man(3) realloc
-    //
-    // If size is zero and ptr is not NULL, a new,
-    // minimum sized object is allocated and 
-    // the original object is freed.
-    if (newsz == 0 && ptr) newsz = oldsz;
-    // realloc() creates a new allocation
-    void * new_p = enif_alloc(newsz);
-    if (new_p) {
-        // If ptr is NULL, realloc() is identical to a call to
-        // malloc() for size bytes.
-        if (ptr != NULL) {
-            // copies as much of the old data pointed to by ptr
-            // as will fit to the new allocation
-            size_t sz = oldsz;
-            if (newsz < sz) sz = newsz;
-            memcpy(new_p, ptr, sz);
-            // frees the old allocation
-            enif_free(ptr);
-        }
-    }
-    return new_p;
-}
-#define STBI_REALLOC_SIZED nif_realloc
+#define STBI_REALLOC enif_realloc
 #define STBI_FREE enif_free
 #include <stb_image.h>
 #include <stb_image_write.h>

--- a/c_src/stb_image_nif.c
+++ b/c_src/stb_image_nif.c
@@ -1,5 +1,4 @@
 #include <erl_nif.h>
-#include <string.h>
 #define STBI_NO_FAILURE_STRINGS
 #define STB_IMAGE_IMPLEMENTATION
 #define STB_IMAGE_WRITE_IMPLEMENTATION


### PR DESCRIPTION
Use the internal erlang memory allocators instead of doing system calls (malloc/realloc/free)