### PR TITLE
Remove unused `CFLAGS`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,4 @@ build: $(STB_IMAGE_NIF_SO)
 
 $(STB_IMAGE_NIF_SO): $(C_SRC)/nif_utils.h $(C_SRC)/stb_image_nif.c
 	@ mkdir -p $(PRIV_DIR)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(C_SRC)/stb_image_nif.c -o $(STB_IMAGE_NIF_SO)
+	$(CC) $(CPPFLAGS) $(C_SRC)/stb_image_nif.c -o $(STB_IMAGE_NIF_SO)


### PR DESCRIPTION
`CFLAGS` is not used anywhere, and it causes a compilation issue when integrating with nerves.