### PR TITLE
Do not leak FDs

### DIFF
--- a/c_src/stb_image_nif.c
+++ b/c_src/stb_image_nif.c
@@ -77,6 +77,7 @@ static ERL_NIF_TERM read_file(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
 
     ERL_NIF_TERM ret = pack_data(env, data, x, y, n, bytes_per_channel);
     STBI_FREE((void *)data);
+    fclose(f);
     return ret;
 }
 


### PR DESCRIPTION
I was messing around with opening up a lot of images, and ended up getting an error related to not having enough FDs. I think we are leaking `f` in `read_file`, which this PR addresses