### PR TITLE
set runtime to false for :elixir_make

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule StbImage.MixProject do
 
   defp deps do
     [
-      {:elixir_make, "~> 0.6"},
+      {:elixir_make, "~> 0.6", runtime: false},
       {:nx, "~> 0.1", optional: true},
       {:ex_doc, "~> 0.23", only: :docs, runtime: false}
     ]


### PR DESCRIPTION
`:elixir_make` should not be in runtime.