### PR TITLE
Support UTF-8 characters in filepath.

### DIFF
--- a/c_src/stb_image_nif.c
+++ b/c_src/stb_image_nif.c
@@ -6,6 +6,7 @@
 #define STBI_MALLOC enif_alloc
 #define STBI_REALLOC enif_realloc
 #define STBI_FREE enif_free
+#define STBI_WINDOWS_UTF8
 #include <stb_image.h>
 #include <stb_image_write.h>
 #include <stb_image_resize.h>

--- a/c_src/stb_image_nif.c
+++ b/c_src/stb_image_nif.c
@@ -191,8 +191,9 @@ static ERL_NIF_TERM write_file(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv
         return error(env, "expecting 6 arguments: path, format, data, height, width, and number of channels");
     }
 
-    char * c_path = NULL, * c_format = NULL;
-    ErlNifBinary path, format;
+    char * c_path = NULL;
+    char format[MAX_EXTNAME_LENGTH];
+    ErlNifBinary path;
     ErlNifBinary result;
     int w, h, comp;
 
@@ -200,17 +201,13 @@ static ERL_NIF_TERM write_file(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv
         return error(env, "invalid path");
     }
 
-    if (!enif_inspect_binary(env, argv[1], &format)) {
+    if (!enif_get_atom(env, argv[1], format, sizeof(format), ERL_NIF_LATIN1)) {
         return error(env, "invalid format");
     }
 
     c_path = enif_alloc(path.size + 1);
     memcpy(c_path, path.data, path.size);
     c_path[path.size] = '\0';
-    
-    c_format = enif_alloc(format.size + 1);
-    memcpy(c_format, format.data, format.size);
-    c_format[format.size] = '\0';
 
     if (!enif_inspect_binary(env, argv[2], &result)) {
         return error(env, "invalid binary data");
@@ -225,29 +222,29 @@ static ERL_NIF_TERM write_file(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv
         return error(env, "invalid number of channels");
     }
 
-    if (strcmp(c_format, "png") == 0) {
+    if (strcmp(format, "png") == 0) {
         int stride_in_bytes = 0;
         int status = stbi_write_png(c_path, w, h, comp, result.data, stride_in_bytes);
         if (!status) {
             return error(env, "failed to write png");
         }
-    } else if (strcmp(c_format, "bmp") == 0) {
+    } else if (strcmp(format, "bmp") == 0) {
         int status = stbi_write_bmp(c_path, w, h, comp, result.data);
         if (!status) {
             return error(env, "failed to write bmp");
         }
-    } else if (strcmp(c_format, "tga") == 0) {
+    } else if (strcmp(format, "tga") == 0) {
         int status = stbi_write_tga(c_path, w, h, comp, result.data);
         if (!status) {
             return error(env, "failed to write tga");
         }
-    } else if (strcmp(c_format, "jpg") == 0) {
+    } else if (strcmp(format, "jpg") == 0) {
         int quality = 100;
         int status = stbi_write_jpg(c_path, w, h, comp, result.data, quality);
         if (!status) {
             return error(env, "failed to write jpg");
         }
-    } else if (strcmp(c_format, "hdr") == 0) {
+    } else if (strcmp(format, "hdr") == 0) {
         int status = stbi_write_hdr(c_path, w, h, comp, (float*)result.data);
         if (!status) {
             return error(env, "failed to write hdr");

--- a/c_src/stb_image_nif.c
+++ b/c_src/stb_image_nif.c
@@ -59,14 +59,13 @@ static ERL_NIF_TERM read_file(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
     if (!enif_inspect_binary(env, argv[0], &path)) {
         return error(env, "invalid path");
     }
+    if(!enif_get_int(env, argv[1], &desired_channels)) {
+        return error(env, "invalid channels");
+    }
+
     c_path = enif_alloc(path.size + 1);
     memcpy(c_path, path.data, path.size);
     c_path[path.size] = '\0';
-
-    if(!enif_get_int(env, argv[1], &desired_channels)) {
-        ret = error(env, "invalid channels");
-        goto free_c_path;
-    }
 
     int x, y, n;
     unsigned char *data;
@@ -86,7 +85,7 @@ static ERL_NIF_TERM read_file(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
     }
 
     ret = pack_data(env, data, x, y, n, bytes_per_channel);
-    
+
     fclose(f);
     STBI_FREE((void *)data);
 

--- a/c_src/stb_image_nif.c
+++ b/c_src/stb_image_nif.c
@@ -7,6 +7,7 @@
 #define STBI_REALLOC enif_realloc
 #define STBI_FREE enif_free
 #define STBI_WINDOWS_UTF8
+#define STBIW_WINDOWS_UTF8
 #include <stb_image.h>
 #include <stb_image_write.h>
 #include <stb_image_resize.h>

--- a/lib/stb_image.ex
+++ b/lib/stb_image.ex
@@ -354,7 +354,7 @@ defmodule StbImage do
     end
   end
 
-  defp path_to_binary(path) when is_list(path), do: to_string(path)
+  defp path_to_binary(path) when is_list(path), do: List.to_string(path)
   defp path_to_binary(path) when is_binary(path), do: path
 
   defp type(:u8), do: {:u, 8}

--- a/lib/stb_image.ex
+++ b/lib/stb_image.ex
@@ -126,7 +126,7 @@ defmodule StbImage do
   def read_file(path, opts \\ []) when is_path(path) and is_list(opts) do
     channels = opts[:channels] || 0
 
-    case StbImage.Nif.read_file(path_to_charlist(path), channels) do
+    case StbImage.Nif.read_file(path_to_binary(path), channels) do
       {:ok, img, shape, bytes} ->
         {:ok, %StbImage{data: img, shape: shape, type: bytes_to_type(bytes)}}
 
@@ -249,7 +249,7 @@ defmodule StbImage do
     format = opts[:format] || format_from_path!(path)
     assert_write_type_and_format!(type, format)
 
-    case StbImage.Nif.write_file(path_to_charlist(path), format, data, height, width, channels) do
+    case StbImage.Nif.write_file(path_to_binary(path), format, data, height, width, channels) do
       :ok -> :ok
       {:error, reason} -> {:error, List.to_string(reason)}
     end
@@ -354,8 +354,8 @@ defmodule StbImage do
     end
   end
 
-  defp path_to_charlist(path) when is_list(path), do: path
-  defp path_to_charlist(path) when is_binary(path), do: String.to_charlist(path)
+  defp path_to_binary(path) when is_list(path), do: to_string(path)
+  defp path_to_binary(path) when is_binary(path), do: path
 
   defp type(:u8), do: {:u, 8}
   defp type(:f32), do: {:f, 32}

--- a/test/stb_image_test.exs
+++ b/test/stb_image_test.exs
@@ -153,7 +153,6 @@ defmodule StbImageTest do
 
   test "read/write file with UTF-8 characters in filename" do
     try do
-      File.mkdir("tmp")
       File.cp(Path.join(__DIR__, "test.png"), Path.join(__DIR__, "テスト.png"))
 
       img = StbImage.read_file!(Path.join(__DIR__, "テスト.png"))


### PR DESCRIPTION
Filepath should be passed as binary to NIF, otherwise, it prevents reading/writing files with UTF-8 characters.

### Before

<img width="917" alt="Screenshot 2022-11-06 at 02 43 18" src="https://user-images.githubusercontent.com/89497197/200151617-6e9245fe-b979-4df2-8a78-0816f04ac806.png">

### After

<img width="922" alt="Screenshot 2022-11-06 at 02 46 07" src="https://user-images.githubusercontent.com/89497197/200151622-56e8ec96-7117-4a0f-918e-ab34e26f82f9.png">

