### PR TITLE
fix: null pointer dereference

### DIFF
--- a/3rd_party/stb/stb_image.h
+++ b/3rd_party/stb/stb_image.h
@@ -6450,7 +6450,7 @@ static void *stbi__pic_load(stbi__context *s,int *px,int *py,int *comp,int req_c
 
    if (!stbi__pic_load_core(s,x,y,comp, result)) {
       STBI_FREE(result);
-      result=0;
+      return 0;
    }
    *px = x;
    *py = y;


### PR DESCRIPTION
Related issue: https://github.com/nothings/stb/issues/1452

> Specifically, if the `stbi__pic_load_core` function returns 0 (line 6451), `result` will be released (line 6452) and set to 0 (line 6453). This null pointer will be dereferenced in `stbi__convert_format`, which would crash the application.

(line numbers have been modified to reflect corresponding lines in our copy of `stb_image.h`)

https://github.com/elixir-nx/stb_image/blob/0f61480b02f25b00007465f3bf44da2b80a46792/3rd_party/stb/stb_image.h#L6451-L6458

This PR applies [Neil Bickford](https://github.com/NeilBickford-NV)'s fix submitted at the stb repo.

Related PR: https://github.com/nothings/stb/pull/1454